### PR TITLE
Implement First Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'faraday'
 group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails'
+  gem 'factory_girl_rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 gem 'figaro'
 gem 'faraday'
+gem "active_model_serializers", github: "rails-api/active_model_serializers"
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,11 @@ GEM
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
@@ -144,6 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  factory_girl_rails
   faraday
   figaro
   listen (~> 3.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/rails-api/active_model_serializers.git
+  revision: 4ff33a7ad1f1d1f9e1254bb15301bd7b82441d5e
+  specs:
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -57,6 +67,9 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -148,6 +161,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   byebug
   factory_girl_rails
   faraday

--- a/app/controllers/api/v1/status_controller.rb
+++ b/app/controllers/api/v1/status_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::StatusController < ApiBaseController
   def index
-    @version = Status.first
+    @version = Status.order(created_at: :desc).first
     render json: @version
   end
 end

--- a/app/controllers/api/v1/status_controller.rb
+++ b/app/controllers/api/v1/status_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::StatusController < ApiBaseController
+  def index
+    @version = Status.first
+    render json: @version
+  end
+end

--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -1,0 +1,3 @@
+class ApiBaseController < ActionController::API
+
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,2 @@
+class Status < ApplicationRecord
+end

--- a/app/serializers/status_serializer.rb
+++ b/app/serializers/status_serializer.rb
@@ -1,0 +1,7 @@
+class StatusSerializer < ActiveModel::Serializer
+  attributes :version, :last_update
+
+  def last_update
+    object.created_at.strftime("%m/%d/%Y at %I:%M%p")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, defaults: {format: :json} do
+    namespace :v1 do
+      resources :status, only: [:index]
+    end
+  end
 end

--- a/db/migrate/20160727055711_create_statuses.rb
+++ b/db/migrate/20160727055711_create_statuses.rb
@@ -1,0 +1,9 @@
+class CreateStatuses < ActiveRecord::Migration[5.0]
+  def change
+    create_table :statuses do |t|
+      t.string :version
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160727055711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "statuses", force: :cascade do |t|
+    t.string   "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :status do
+    version
+  end
+
+  sequence :vesion do |n|
+    "0.0.#{n}"
+  end
+end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     version
   end
 
-  sequence :vesion do |n|
+  sequence :version do |n|
     "0.0.#{n}"
   end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Status, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'support/factory_girl'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -14,4 +14,17 @@ describe "Status Endpoint" do
     expect(parsed_status["version"]).to eq "0.0.1"
     expect(parsed_status["last_update"]).to eq formatted_created_at
   end
+
+  it "pulls the newest status information" do
+    status = create(:status, version: "0.0.1", created_at: "2012-03-27T14:53:59.000Z")
+    newer_status = create(:status, version: "0.0.2")
+
+    get "/api/v1/status"
+
+    expect(response).to be_success
+
+    parsed_status = JSON.parse(response.body)
+
+    expect(parsed_status["version"]).to eq "0.0.2"
+  end
 end

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -10,7 +10,7 @@ describe "Status Endpoint" do
 
     parsed_status = JSON.parse(response.body)
 
-    expect(parsed_status.version).to eq "0.0.1"
-    expect(parsed_status.last_update).to eq status.created_at
+    expect(parsed_status["version"]).to eq "0.0.1"
+    expect(parsed_status["last_update"]).to eq status.created_at
   end
 end

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "Status Endpoint" do
+  it "Sends status information for the server" do
+    status = create(:status, version: "0.0.1")
+
+    get "/api/v1/status"
+
+    expect(response).to be_success
+
+    parsed_status = JSON.parse(response.body)
+
+    expect(parsed_status.version).to eq "0.0.1"
+    expect(parsed_status.last_update).to eq status.created_at
+  end
+end

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe "Status Endpoint" do
   it "Sends status information for the server" do
     status = create(:status, version: "0.0.1")
+    formatted_created_at = status.created_at.strftime("%m/%d/%Y at %I:%M%p")
 
     get "/api/v1/status"
 
@@ -11,6 +12,6 @@ describe "Status Endpoint" do
     parsed_status = JSON.parse(response.body)
 
     expect(parsed_status["version"]).to eq "0.0.1"
-    expect(parsed_status["last_update"]).to eq status.created_at
+    expect(parsed_status["last_update"]).to eq formatted_created_at
   end
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
Added basic endpoint for server status data.

Changes:
- Add spec for status endpoint
- Add status endpoint at `api/v1/status`
- Adjust status endpoint to return only the newest entry

Closes #3
