### PR TITLE
Feature/add initial minion endpoints

### DIFF
--- a/app/controllers/api/v1/minion_controller.rb
+++ b/app/controllers/api/v1/minion_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::MinionController < SecureApiBaseController
+  def index
+    render json: current_user.minion
+  end
+end

--- a/app/controllers/api/v1/minion_controller.rb
+++ b/app/controllers/api/v1/minion_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::MinionController < SecureApiBaseController
   def index
     render json: current_user.minion
   end
+
+  def create
+    render json: Minion.create(name: params[:name], user: current_user)
+  end
 end

--- a/app/serializers/minion_serializer.rb
+++ b/app/serializers/minion_serializer.rb
@@ -1,0 +1,9 @@
+class MinionSerializer < ActiveModel::Serializer
+  attributes :name, :level, :xp, :current_health, :current_stamina,
+             :current_happiness, :total_health, :total_stamina,
+             :total_happiness, :last_ate
+
+  def last_ate
+    object.last_ate.to_s
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :status, only: [:index]
+      resources :minion, only: [:index]
       
       get 'current_user', to: "current_user#index"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :status, only: [:index]
-      resources :minion, only: [:index]
-      
+      resources :minion, only: [:index, :create]
+
       get 'current_user', to: "current_user#index"
     end
   end

--- a/db/migrate/20160801082316_add_default_value_to_status_for_user.rb
+++ b/db/migrate/20160801082316_add_default_value_to_status_for_user.rb
@@ -1,0 +1,6 @@
+class AddDefaultValueToStatusForUser < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :status
+    add_column :users, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801060858) do
+ActiveRecord::Schema.define(version: 20160801082316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,11 +70,11 @@ ActiveRecord::Schema.define(version: 20160801060858) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "uid",        null: false
-    t.string   "name",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer  "status"
+    t.string   "uid",                    null: false
+    t.string   "name",                   null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "status",     default: 0
     t.index ["uid"], name: "index_users_on_uid", using: :btree
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -7,6 +7,12 @@ FactoryGirl.define do
     name
     uid
     status 0
+
+    trait :with_minion do
+      after :create do |user|
+        FactoryGirl.create(:minion, user: user)
+      end
+    end
   end
 
   factory :minion do

--- a/spec/requests/api/v1/minion_spec.rb
+++ b/spec/requests/api/v1/minion_spec.rb
@@ -24,4 +24,20 @@ describe "Minion Endpoint" do
     expect(parsed_minion["last_ate"]).to eq user.minion.last_ate.to_s
     expect(parsed_minion["user_id"]).to eq nil
   end
+
+  it "returns the minion for the current user" do
+    user = create(:user)
+    jwt = JWT.encode({uid: user.uid, exp: 1.day.from_now.to_i},
+                Rails.application.secrets.secret_key_base)
+
+    post "/api/v1/minion", headers: {'Authorization' => jwt},
+                           params: {name: "Test"}
+
+    expect(response).to be_success
+
+    parsed_minion = JSON.parse(response.body)
+
+    expect(parsed_minion["name"]).to eq "Test"
+    expect(user.minion.name).to eq "Test"
+  end
 end

--- a/spec/requests/api/v1/minion_spec.rb
+++ b/spec/requests/api/v1/minion_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe "Minion Endpoint" do
+  it "returns the minion for the current user" do
+    user = create(:user, :with_minion)
+    jwt = JWT.encode({uid: user.uid, exp: 1.day.from_now.to_i},
+                Rails.application.secrets.secret_key_base)
+
+    get "/api/v1/minion", headers: {'Authorization' => jwt}
+
+    expect(response).to be_success
+
+    parsed_minion = JSON.parse(response.body)
+
+    expect(parsed_minion["name"]).to eq user.minion.name
+    expect(parsed_minion["level"]).to eq user.minion.level
+    expect(parsed_minion["xp"]).to eq user.minion.xp
+    expect(parsed_minion["current_health"]).to eq user.minion.current_health
+    expect(parsed_minion["current_stamina"]).to eq user.minion.current_stamina
+    expect(parsed_minion["current_happiness"]).to eq user.minion.current_happiness
+    expect(parsed_minion["total_health"]).to eq user.minion.total_health
+    expect(parsed_minion["total_stamina"]).to eq user.minion.total_stamina
+    expect(parsed_minion["total_happiness"]).to eq user.minion.total_happiness
+    expect(parsed_minion["last_ate"]).to eq user.minion.last_ate.to_s
+    expect(parsed_minion["user_id"]).to eq nil
+  end
+end


### PR DESCRIPTION
Added the first pair of endpoints for viewing and creating minions from the client.
- Added `GET /minion` endpoint
- Added `POST /minion?name=NAME` endpoint

Closes #24 
Closes #25
