### PR TITLE
Adjust tests reliant on date to have a set date

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe User, type: :model do
 
     user = User.login_with_facebook(example_access_token)
     user_last_match_pull = user.last_match_pull.strftime("%Y%m%d")
-    expected_match_pull = Time.now.strftime("%Y%m%d")
+    expected_match_pull = Time.new(2016,8,4).strftime("%Y%m%d")
 
     expect(user).to eq User.first
     expect(user.uid).to eq ("1")
@@ -69,7 +69,7 @@ RSpec.describe User, type: :model do
 
     user.get_matches
     actual_match_pull = user.last_match_pull.strftime("%Y%m%d")
-    expected_match_pull = Time.now.strftime("%Y%m%d")
+    expected_match_pull = Time.new(2016,8,4).strftime("%Y%m%d")
 
     expect(actual_match_pull).to eq expected_match_pull
   end


### PR DESCRIPTION
Fixed date tests to have an expected date, rather than Date.now. This should resolve issues where the time has passed in various time zones.
- adjusted two tests in the User Spec to use a specific date for testing
